### PR TITLE
Revert "Small bug -> składnia"

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2483,7 +2483,7 @@ void MainWindow::createBackup() {
 
     if (JlCompress::compressDir(directoryComboBox->text() + QString("/") +
                                     fileComboBox->text() + QString(".zip"),
-                                sett().getWorkingDir(), QDir::AllDirs) &&
+                                sett().getWorkingDir(), true, QDir::AllDirs) &&
         JlCompress::compressFiles(directoryComboBox->text() + QString("/") +
                                       fileComboBox->text() +
                                       QString("-configs.zip"),


### PR DESCRIPTION
Reverts juliagoda/qfaktury#39, błąd przy kompilacji o treści następującej: 

> mainwindow.cpp:2486:70: error: enum constant in boolean context [-Werror=int-in-bool-context]